### PR TITLE
Logic Readout Wrapping Fix

### DIFF
--- a/src/styleguide/styles.scss
+++ b/src/styleguide/styles.scss
@@ -35,16 +35,15 @@ $UI_BUTTON: #694C79;
 // Readouts inside the logic browse pane
 .filtered-item-title-logic-readout {
   display: flex;
+  flex-wrap: wrap;
   font-size: 11px;
   margin-top: 4px;
 }
 
 .logic-group {
   display: flex;
-
-  & + & {
-    margin-left: 8px;
-  }
+  flex-wrap: wrap;
+  margin-right: 8px;
 
   & svg {
     width: 12px;


### PR DESCRIPTION
Resolves #19 so that long logic readouts don't push the settings and remove button out of the pane