### PR TITLE
Checking ref instead of class

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
-var spaceName = 'clay-space',
-  selector = require('./services/selector'),
+var selector = require('./services/selector'),
   SpaceController = require('./controllers/space-controller'),
   utils = require('./services/utils');
 
@@ -7,7 +6,7 @@ var spaceName = 'clay-space',
 require('./styleguide/styles.scss');
 
 function updateSelector(el, options, parent) {
-  var isSpaceComponent = el.classList.contains(spaceName),
+  var isSpaceComponent = utils.checkIfSpace(options.ref),
     availableSpaces = utils.spaceInComponentList(parent);
 
   if (availableSpaces && availableSpaces.length > 0 && !isSpaceComponent) {

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -59,8 +59,18 @@ function createFilterableList(items, callbacks) {
   return references.filterableList.create(items, callbacks);
 }
 
+/**
+ * Checks if a reference is a type of Space.
+ *
+ * @param  {String} ref The uri of a component
+ * @return {Boolean}
+ */
+function checkIfSpace(ref) {
+  return _.includes(ref, references.spacePrefix);
+}
+
 module.exports.makeComponentListAttr = makeComponentListAttr;
 module.exports.spaceInComponentList = spaceInComponentList;
 module.exports.availableSpaces = availableSpaces;
 module.exports.createFilterableList = createFilterableList;
-
+module.exports.checkIfSpace = checkIfSpace;


### PR DESCRIPTION
Ensures that a Space doesn't need a specific class on it for the edit experience to be applied properly.