### PR TITLE
Fixes issue in which target button was keeping overlay over space logic

### DIFF
--- a/src/controllers/space-settings-controller.js
+++ b/src/controllers/space-settings-controller.js
@@ -338,9 +338,8 @@ proto.listItemClick = function (id) {
  * @param  {string} id
  */
 proto.settings = function (id) {
-  references.focus.unfocus().then(function () {
-    return references.forms.open(id, document.body);
-  }).catch(_.noop);
+  references.pane.close();
+  references.forms.open(id, document.body);
 };
 
 /**


### PR DESCRIPTION
What's happening: When clicking a target button inside a space-browse pane, the space logic settings window appears, but it appears _under_ and overlay.

Why: The form and the pane (and their shims) are separate. Kiln is not designed, perhaps intentionally, so that a pane and a form can be open simultaneously.

The fix: This change closes the pane before opening the space logic form. Once the user closes the space logic form, the pane re-opens.