### PR TITLE
Reinitialize space component when selector is added to child

### DIFF
--- a/src/controllers/space-controller.js
+++ b/src/controllers/space-controller.js
@@ -7,28 +7,15 @@ var dom = require('@nymag/dom'),
   proto = SpaceController.prototype;
 
 function SpaceController(el, parent) {
-  // if (!Object.keys(parent).length) {
-  //   // Whenever a new space is first created, Kiln does not
-  //   // have reference to its parent's schema/component list
-  //   // information. Because of this we can't add new components
-  //   // properly. To fix this, trigger a reload if this
-  //   // is a brand new Space component.
-  //   window.location.reload();
-  // }
-  var self = this,
-    reinitialize = _.debounce(function () {
-      self.init();
-    }, 100);
+  const reinitialize = _.debounce(this.init.bind(this), 100);
 
   this.el = el;
 
   this.parent = parent;
 
-  this.childrenLogics;
+  this.childrenLogics = {};
 
   this.el.setAttribute('data-components', utils.makeComponentListAttr(this.parent));
-
-  this.spaceRef = this.el.getAttribute('data-uri');
 
   window.kiln.on('save', (component) => {
     var componentElement = dom.find(this.el, '[data-uri="' + component._ref + '"]'),
@@ -50,8 +37,8 @@ function SpaceController(el, parent) {
   });
 
   // Reinitialize space when selectors are added to its children.
-  window.kiln.on('add-selector', function (childEl) {
-    if (self.ownsComponent(childEl)) {
+  window.kiln.on('add-selector', (childEl) => {
+    if (this.ownsComponent(childEl)) {
       reinitialize();
     }
   });

--- a/src/controllers/space-controller.js
+++ b/src/controllers/space-controller.js
@@ -15,6 +15,7 @@ function SpaceController(el, parent) {
   //   // is a brand new Space component.
   //   window.location.reload();
   // }
+  var self = this;
 
   this.el = el;
 
@@ -45,6 +46,12 @@ function SpaceController(el, parent) {
     }
   });
 
+  // Reinitialize space when selectors are added to its children.
+  window.kiln.on('add-selector', function (childEl) {
+    if (self.ownsComponent(childEl)) {
+      self.init();
+    }
+  });
 
   this.init();
 }
@@ -73,7 +80,7 @@ proto.findFirstActive = function () {
 };
 
 /**
- * Called after a componet is added to a space
+ * Called after a component is added to a space
  * @param {Element} newEl [description]
  */
 proto.onAddCallback = function (newEl) {
@@ -126,6 +133,7 @@ proto.onRemoveCallback = function (component) {
  * @returns {SpaceController}
  */
 proto.addButtons = function () {
+
   _.each(this.childrenLogics, (logic) => {
     selectorService.addBrowseButton.call(this, logic);
     selectorService.addRemoveButton.call(this, logic);
@@ -180,6 +188,15 @@ proto.clearEditing = function () {
   });
 
   return this;
+};
+
+/**
+ * Returns true if this cmptEl belongs to this space.
+ * @param  {Element} cmptEl
+ * @return {Boolean}
+ */
+proto.ownsComponent = function (cmptEl) {
+  return _.get(cmptEl, 'parentNode.parentNode') === this.el;
 };
 
 module.exports = function (el, parent) {

--- a/src/controllers/space-controller.js
+++ b/src/controllers/space-controller.js
@@ -15,7 +15,10 @@ function SpaceController(el, parent) {
   //   // is a brand new Space component.
   //   window.location.reload();
   // }
-  var self = this;
+  var self = this,
+    reinitialize = _.debounce(function () {
+      self.init();
+    }, 100);
 
   this.el = el;
 
@@ -49,7 +52,7 @@ function SpaceController(el, parent) {
   // Reinitialize space when selectors are added to its children.
   window.kiln.on('add-selector', function (childEl) {
     if (self.ownsComponent(childEl)) {
-      self.init();
+      reinitialize();
     }
   });
 

--- a/src/services/selector.js
+++ b/src/services/selector.js
@@ -76,7 +76,7 @@ function revealAddComponentButton(el) {
 
 /**
  * [addBrowseButton description]
- * @param {[type]} logicComponent
+ * @param {Element} logicComponent
  * @return {SpaceController}
  */
 function addBrowseButton(logicComponent) {


### PR DESCRIPTION
Relates to [Trello](https://trello.com/c/KX9yJXVa/1374-fix-broken-clay-space-edit). Specifically, due to changes in Kiln, the space-browse button is no longer appearing on spaces.

Here's what seems to be happening: 
* Space controllers are initialized when Kiln adds selectors to clay-space elements.
* When a controller initializes, it updates the selectors of its children. Therefore, to initialize correctly, the selectors of all of a space's children must exist _before_ the controller initializes.
* Before recent changes to Kiln, Space selectors would consistently be added _after_ selectors were already added to its children. (This might have been a coincidence.)
* After the Kiln changes, Space selectors are now added _before_. Thus, they do not work as expected.

The fix: 
* This change modifies the Space Controller to listen for selectors being added to its children and reinitialize when that occurs.
* For better performance, this reinitialization is wrapped in a debounce function so spaces with many children are not re-initialized dozens of times.