### PR TITLE
fixes bug where the edit form doesn't open if another form is open

### DIFF
--- a/src/controllers/space-settings-controller.js
+++ b/src/controllers/space-settings-controller.js
@@ -340,9 +340,7 @@ proto.listItemClick = function (id) {
 proto.settings = function (id) {
   references.pane.close();
   // close any open forms so that space edit form can open
-  if (references.forms.hasOpenForm()) {
-    references.forms.close();
-  }
+  references.forms.close();
   references.forms.open(id, document.body);
 };
 

--- a/src/controllers/space-settings-controller.js
+++ b/src/controllers/space-settings-controller.js
@@ -339,6 +339,10 @@ proto.listItemClick = function (id) {
  */
 proto.settings = function (id) {
   references.pane.close();
+  // close any open forms so that space edit form can open
+  if (references.forms.hasOpenForm()) {
+    references.forms.close();
+  }
   references.forms.open(id, document.body);
 };
 


### PR DESCRIPTION
[Trello](https://trello.com/c/9Ct13DNi/1379-bug-flash-of-content-within-clay-spaces-causes-wonky-ux)