### PR TITLE
 #53 Adapt for new APIs, Create Space button

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,43 @@
-var invisibleLists = require('./services/invisible-lists'),
-  selectorService = require('./services/selector');
-
-// Load styles
-require('./styleguide/styles.scss');
+import {
+  SELECT
+} from './mutationTypes';
+// import invisibleLists from './services/invisible-lists';
+import selectorService from './services/selector';
+import { closest } from '@nymag/dom';
+const PLUGIN_NAME = 'spaces-edit';
 
 window.kiln = window.kiln || {};
 window.kiln.plugins = window.kiln.plugins || {};
-window.kiln.plugins['spaces-edit'] = function initSpaces() {
-  window.kiln.on('add-selector', selectorService.updateSelector);
-  window.kiln.on('component-pane:create-invisible-tab', invisibleLists);
+
+// TODO: remove this
+window.kiln.on = window.kiln.on || function () {};
+window.kiln.plugins[PLUGIN_NAME] = function spaceEdit(store) {
+  store.subscribe(function spaceEditHandleMutation(mutation, state) {
+    // wrap in a `try` so the UI doesn't stop working entirely
+    // if the DOM scraping below doesn't work
+    try {
+      switch (mutation.type) {
+        case SELECT:
+          const el = mutation.payload,
+            ref = el.dataset.uri,
+            data = state.components[ref],
+            // find the <html> data-layout-uri attribute value
+            layoutRef = document.documentElement.dataset.layoutUri,
+            layoutData = state.components[layoutRef],
+            componentListName = closest(el, '[data-editable]').getAttribute('data-editable'),
+            componentList = layoutData[componentListName];
+
+          if (componentList) {
+            selectorService.updateSelector(el, {data, ref}, state.schemas.layout[componentListName]);
+          }
+          // TODO: fix implementation of invisibleLists
+          // invisibleLists(el);
+          break;
+        default:
+          return;
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  });
 };

--- a/src/mutationTypes.js
+++ b/src/mutationTypes.js
@@ -1,0 +1,2 @@
+/* eslint-disable one-var */
+export const SELECT = 'SELECT';

--- a/src/services/references.js
+++ b/src/services/references.js
@@ -1,29 +1,43 @@
-var _ = require('lodash'),
-  referencesObj,
-  kilnServices;
-
 window.kiln = window.kiln || {};
-window.kiln.services = window.kiln.services || {};
-kilnServices = window.kiln.services;
+window.kiln.utils = window.kiln.utils || {};
+const kilnUtils = window.kiln.utils;
 
-referencesObj = _.assign({
+/**
+ * replacement for kilnUtils.tpl.get
+ * Given a CSS selector, returns the result of using
+ * the template (from template.hbs) to create a DOM element.
+ * If the template is not found, returns `null`.
+ * @return {Object | null}
+ * @param {String} templateSelector
+ */
+function getFromTemplate(selector) {
+  const el = document.querySelector(selector);
+
+  if (!el || !el.content) {
+    throw new Error(`Template for selector ${selector} not found`);
+  }
+
+  return document.importNode(el.content, true);
+};
+
+
+// TODO: use ES2015`export`
+module.exports = {
   spaceEdit: 'clay-space-edit',
   spacePrefix: 'clay-space',
   dataAvailableSpaces: 'data-spaces-available',
   dataPaneTitle: 'data-space-browse-title',
-  render: kilnServices.render,
-  focus: kilnServices.focus,
-  forms: kilnServices.forms,
-  select: kilnServices.select,
-  pane: kilnServices.pane,
-  select: kilnServices.select,
-  edit: kilnServices.edit,
-  label: kilnServices.label,
-  addComponent: kilnServices['add-component'],
-  availableComponents: kilnServices.availableComponents,
-  tpl: kilnServices.tpl,
-  filterableList: kilnServices['filterable-list'],
-  site: kilnServices.site
-}, kilnServices.references);
-
-module.exports = referencesObj;
+  render: kilnUtils.render,
+  focus: kilnUtils.focus,
+  forms: kilnUtils.forms,
+  select: kilnUtils.select,
+  pane: kilnUtils.pane,
+  select: kilnUtils.select,
+  edit: kilnUtils.edit,
+  label: kilnUtils.label,
+  addComponent: kilnUtils['add-component'],
+  availableComponents: kilnUtils.getAvailableComponents,
+  getFromTemplate,
+  filterableList: kilnUtils['filterable-list'],
+  site: kilnUtils.site
+};

--- a/src/services/selector.js
+++ b/src/services/selector.js
@@ -1,6 +1,6 @@
 var _ = require('lodash'),
   dom = require('@nymag/dom'),
-  references = require('references'),
+  references = require('./references'),
   utils = require('./utils'),
   createService = require('./create-service'),
   removeService = require('./remove-service'),
@@ -9,13 +9,11 @@ var _ = require('lodash'),
   SpaceController = require('./../controllers/space-controller');
 
 function addCreateSpaceButton(el, options, parent) {
-  var parentButton = dom.find(el, '.selected-actions'),
-    createSpaceButton = references.tpl.get('.create-space'),
-    createButton;
+  const parentButton = dom.find(el, '.selected-actions'),
+    createSpaceButton = references.getFromTemplate('.create-space');
 
   parentButton.appendChild(createSpaceButton);
-  createButton = dom.find(el, '.space-create');
-  createButton.addEventListener('click', createService.createSpace.bind(null, options, parent));
+  createSpaceButton.addEventListener('click', createService.createSpace.bind(null, options, parent));
 }
 
 /**
@@ -176,7 +174,6 @@ function updateSelector(el, options, parent) {
   var availableSpaces;
 
   if (utils.checkIfSpaceEdit(options.ref)) return; // ignore space-edit component
-
   availableSpaces = utils.spaceInComponentList(parent);
 
   if (utils.checkIfSpace(options.ref)) { // if element is space component
@@ -184,9 +181,11 @@ function updateSelector(el, options, parent) {
     SpaceController(el, parent);
     addToComponentList(el, options, parent);
   } else if (!_.isEmpty(availableSpaces)) { // if element is space sibling
-    addAvailableSpaces(el, availableSpaces);
+    // addAvailableSpaces(el, availableSpaces);
     addCreateSpaceButton(el, options, parent);
-    stripSpaceFromComponentList(el);
+    // TODO: figure this out, now that we're using Vuex
+    // we don't want it to be possible to add a space directly
+    // stripSpaceFromComponentList(el);
   }
 }
 

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -1,6 +1,6 @@
 var dom = require('@nymag/dom'),
   _ = require('lodash'),
-  references = require('references');
+  references = require('./references');
 
 /**
  * Return an array of components available in a
@@ -29,11 +29,11 @@ function makeComponentListAttr(parent) {
  * @return {String[]}  The names of available space components, e.g. "clay-space" or "clay-space-ads"
  */
 function spaceInComponentList(parent) {
-  var include = _.get(parent, 'list.include', '') || _.get(parent, 'prop.include', ''),
-    exclude = _.get(parent, 'list.exclude', '') || _.get(parent, 'prop.exclude', '');
+  const possibleComponents = _.get(parent, '_componentList.include', []),
+    exclude = _.get(parent, '_componentList.exclude', []);
 
   // Filter out components that are not Space components nor the Edit component
-  return _.filter(references.availableComponents(include, exclude), function (item) {
+  return _.filter(references.availableComponents(possibleComponents, exclude), function (item) {
     return _.startsWith(item, references.spacePrefix) && item !== references.spaceEdit;
   });
 }


### PR DESCRIPTION
Fix #53 

# Changes

- Use Vuex to detect when selection changes
- Use Vuex store to to find  layout data, componentList
- Use new kiln.utils to get available components
- Implement getFromTemplate because Kiln API gone

## To Test
- Run a Clay instance and npm link the vue version of Kiln and the version of clay-space-edit in this branch
- Click a component that can be converted into a space
- The create-space icon should display:
![screen shot 2017-05-01 at 4 32 00 pm](https://cloud.githubusercontent.com/assets/4691093/25595916/aad39e46-2e94-11e7-93dd-b6e77357f985.jpg)


