### PR TITLE
#33 upgrade to Webpack 2 and  #52 set up vue-loader 

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,5 @@
 {
-  "presets": ["es2015"]
+  "presets": [
+    ["es2015", { "modules" : false }]
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "bootstrap.yml"
   ],
   "homepage": "https://github.com/nymag/clay-space-edit#readme",
-  "dependencies": {
+  "devDependencies": {
     "@nymag/dom": "^1.3.1",
     "babel-core": "^6.14.0",
     "babel-loader": "^6.2.5",
@@ -44,6 +44,10 @@
     "node-sass": "^3.8.0",
     "sass-loader": "^4.0.0",
     "style-loader": "^0.13.1",
-    "webpack": "^1.13.2"
+    "webpack": "^1.13.2",
+    "vue": "^2.3.2",
+    "vue-loader": "^12.0.2",
+    "vue-style-loader": "^3.0.0",
+    "vue-template-compiler": "^2.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,19 +35,19 @@
   "devDependencies": {
     "@nymag/dom": "^1.3.1",
     "babel-core": "^6.14.0",
-    "babel-loader": "^6.2.5",
+    "babel-loader": "^7.0.0",
     "babel-preset-es2015": "^6.14.0",
     "css-loader": "^0.24.0",
     "eslint": "^3.3.1",
-    "extract-text-webpack-plugin": "^1.0.1",
+    "extract-text-webpack-plugin": "^2.1.0",
     "lodash": "^4.14.2",
     "node-sass": "^3.8.0",
     "sass-loader": "^4.0.0",
     "style-loader": "^0.13.1",
-    "webpack": "^1.13.2",
     "vue": "^2.3.2",
     "vue-loader": "^12.0.2",
     "vue-style-loader": "^3.0.0",
-    "vue-template-compiler": "^2.3.2"
+    "vue-template-compiler": "^2.3.2",
+    "webpack": "^2.4.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,20 +8,29 @@ module.exports = {
     path: './dist'
   },
   module: {
-    loaders: [{
-      test: /\.js$/,
-      exclude: /node_modules/,
-      loader: 'babel',
-      query: {
-        presets: ['es2015'],
-      }
-    }, {
-      test: /\.scss$/,
-      loader: ExtractTextPlugin.extract(
-        'style', // backup loader when not building .css file
-        'css!sass' // loaders to preprocess CSS
-      )
-    }]
+    loaders: [
+      {
+        test: /\.vue$/,
+        loader: 'vue-loader',
+        options: {
+          extractCSS: process.env.NODE_ENV === 'production',
+          preserveWhitespace: !process.env.NODE_ENV === 'production'
+        }
+      },
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: 'babel',
+        query: {
+          presets: ['es2015'],
+        }
+      }, {
+        test: /\.scss$/,
+        loader: ExtractTextPlugin.extract(
+          'style', // backup loader when not building .css file
+          'css!sass' // loaders to preprocess CSS
+        )
+      }]
   },
   resolve: {
     alias: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,32 +5,45 @@ module.exports = {
   entry: './src/index.js',
   output: {
     filename: 'clay-space-edit.js',
-    path: './dist'
+    path: path.resolve(__dirname, './dist')
   },
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.vue$/,
-        loader: 'vue-loader',
-        options: {
-          extractCSS: process.env.NODE_ENV === 'production',
-          preserveWhitespace: !process.env.NODE_ENV === 'production'
-        }
+        use: [
+          {
+            loader: 'vue-loader',
+            options: {
+              extractCSS: process.env.NODE_ENV === 'production',
+              preserveWhitespace: !process.env.NODE_ENV === 'production'
+            }
+          }
+        ]
       },
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        loader: 'babel',
-        query: {
-          presets: ['es2015'],
-        }
-      }, {
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              presets: ['es2015']
+            }
+          }
+        ]
+      },
+      {
         test: /\.scss$/,
-        loader: ExtractTextPlugin.extract(
-          'style', // backup loader when not building .css file
-          'css!sass' // loaders to preprocess CSS
-        )
-      }]
+        use: ExtractTextPlugin.extract({
+          fallback: 'style-loader', // backup loader when not building .css file
+          use: [
+            'css-loader',
+            'sass-loader'
+          ]
+        })
+      }
+    ]
   },
   resolve: {
     alias: {


### PR DESCRIPTION
- Upgrade to Webpack 2 #33 
- Set up vue-loader #52 . To try it out, check out the
[**tmp-vue-loader-demo**](https://github.com/nymag/clay-space-edit/compare/52-vue-loader...tmp-vue-loader-demo?expand=1) branch and do `npm start`.
- Also changed "dependencies" to "devDependencies" in
package.json. That way users who just want the dist bundle
don't have to pull in all the deps for building clay-space-edit