### PR TITLE
 active component: Handle empty component list

### DIFF
--- a/src/ui/space-ui.vue
+++ b/src/ui/space-ui.vue
@@ -173,7 +173,9 @@ export default {
       const activeContent = contents.find(content => content.display)
                             || (contents.length ? contents[0] : null);
 
-      activeContent.isActive = true;
+      if (activeContent) {
+        activeContent.isActive = true;
+      }
 
       return contents;
 


### PR DESCRIPTION
I made a little mistake here, hoping to patch it: https://github.com/nymag/clay-space-edit/pull/82

in space-ui, in the component list:

- When component list is empty, just don't highlight anything.
    
Currently, it's not possible for the component list in
space-ui to be empty (I think), but it's still probably
better to handle the case when it is empty. I forgot
o wrap `activeContent.isActive` in an `if` before.