### PR TITLE
fixes bug where multiple logics are active at the same time

### DIFF
--- a/src/services/toggle-service.js
+++ b/src/services/toggle-service.js
@@ -34,7 +34,9 @@ export function getActive({ state: { components } }, spaceRef, spaceEl) {
     $firstActive = Array.from(dom.findAll($spaceEl, `[${activeAttr}]`)),
     activeUri;
 
-  if ($firstActive.length > 1) {
+  // account for Logic components that don't have properties set, and will always
+  // have displaySelf: true
+  if ($firstActive.length > 0) {
     activeUri = $firstActive.shift().getAttribute('data-uri');
     forEach($firstActive, removeAttr);
   } else {


### PR DESCRIPTION
... this may happen if multiple Logic components have `displaySelf: true` on page load. The component's `model.js` sets the `data-logic-active` attribute at the same time `clay-space-edit` sets the same attribute on another Logic in the same space. This causes multiple Logics to be active during Edit mode, which is NOT the intended behavior. 