### PR TITLE
changed how parent node is referenced

### DIFF
--- a/src/services/add-service.js
+++ b/src/services/add-service.js
@@ -1,9 +1,9 @@
-import { getAvailableComponents, findSpaceParentUriAndList } from './utils';
+import { getAvailableComponents, findParentUriAndList } from './utils';
 import { findSpaceLogic } from './create-service';
 import { setNewActive } from '../services/toggle-service';
 
 export function findAvailableComponents(store, spaceRef) {
-  const parent = findSpaceParentUriAndList(spaceRef);
+  const parent = findParentUriAndList(spaceRef);
 
   return getAvailableComponents(store, parent.el, parent.list);
 }

--- a/src/services/create-service.js
+++ b/src/services/create-service.js
@@ -1,4 +1,4 @@
-import { findSpaceParentUriAndList } from './utils';
+import { findParentUriAndList } from './utils';
 /**
  * Find the component to convert to a Space, find the Spaces available
  * in the parent's component list, figure out which Space needs to be
@@ -74,7 +74,7 @@ function componentToSpace(store, ref, parentRef, spaceName) {
     // create a space logic component with the target component
     newSpaceLogicCmpt = window.kiln.utils.create.default([{name:'space-logic', data: newSpaceLogicData}]),
     // find the area/componentList/etc where the component resides
-    parentList = findSpaceParentUriAndList(ref).list;
+    parentList = findParentUriAndList(ref).list;
 
   return newSpaceLogicCmpt
     .then((res)=>_.last(res))

--- a/src/services/create-service.test.js
+++ b/src/services/create-service.test.js
@@ -53,7 +53,7 @@ test('create-service', t => {
         },
         // stubs
         stubbedCreateFunction = sinon.stub(window.kiln.utils.create, 'default'),
-        stubbedFindSpaceParentUriAndList = sinon.stub(utils,'findSpaceParentUriAndList'),
+        stubbedFindParentUriAndList = sinon.stub(utils,'findParentUriAndList'),
         stubbedReload = sinon.stub(window.location,'reload');
 
       stubbedCreateFunction.returns(
@@ -63,7 +63,7 @@ test('create-service', t => {
         ])
       );
 
-      stubbedFindSpaceParentUriAndList.returns(
+      stubbedFindParentUriAndList.returns(
         {
           el: 'parentEl',
           uri: 'parentUri',

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -19,9 +19,9 @@ function isRouteUri(string, route) {
  * @param  {string} spaceRef reference to the space components
  * @return {Object}
  */
-export function findSpaceParentUriAndList(spaceRef) {
-  var spaceEl = dom.find(`[data-uri="${spaceRef}"]`),
-    parentList = dom.closest(spaceEl, '[data-editable]'),
+export function findParentUriAndList(ref) {
+  var el = dom.find(`[data-uri="${ref}"]`),
+    parentList = dom.closest(el.parentNode, '[data-editable]'),
     parentEl = dom.closest(parentList, '[data-uri]'),
     parentUri = parentEl.getAttribute('data-uri'),
     parentListName = parentList.getAttribute('data-editable');


### PR DESCRIPTION
-renamed method to reflect reference and not space

There was a bug when converting a news-letter-signout component to a space. Renamed  `findSpaceParentUriAndList` to `findParentUriAndList` on Reubens recommendation.