### PR TITLE
Account for empty spaces

### DIFF
--- a/src/services/toggle-service.js
+++ b/src/services/toggle-service.js
@@ -16,7 +16,9 @@ export function initSpaces(store) {
   forEach(allSpaces, function (space) {
     if (!space.classList.contains('clay-space-edit')) {
       activeUri = getActive(store, space.getAttribute('data-uri'), space);
-      dom.find(`[data-uri="${activeUri}"]`).setAttribute(activeAttr, '');
+      if (activeUri) {
+        dom.find(`[data-uri="${activeUri}"]`).setAttribute(activeAttr, '');
+      }
     }
   });
 }
@@ -40,7 +42,12 @@ export function getActive({ state: { components } }, spaceRef, spaceEl) {
     activeUri = $firstActive.shift().getAttribute('data-uri');
     forEach($firstActive, removeAttr);
   } else {
-    activeUri = get(components, `${spaceRef}.content[0]._ref`);
+    if (!get(components, spaceRef).content.length) {
+      console.warn(`clay-space ${spaceRef} is empty! This component should have been removed.`);
+      activeUri = undefined;
+    } else {
+      activeUri = get(components, spaceRef).content[0]._ref;
+    }
   }
 
   return activeUri;


### PR DESCRIPTION
Users have been deleting `space-logic`s, leaving the parent `space` component empty. Clay-space-edit was suppose to delete the `space` component if it has no children but this is not happening. This has caused the following two errors on prod:

`Cannot read property '_ref' of undefined`, which was fixed in [here](https://github.com/nymag/clay-space-edit/commit/cf1632c6d410889e9e6306f0b31e0f22281d00b8)

but then started happening:
`Cannot read property 'setAttribute' of null`

This fix accounts for empty spaces and those errors should stop showing up in TrackJs